### PR TITLE
Replace auth token with API key

### DIFF
--- a/integration/twilio/flex.yaml
+++ b/integration/twilio/flex.yaml
@@ -1,5 +1,6 @@
 type: meya.twilio.flex.integration
-auth_token: (@ vault.twilio.auth_token )
+api_key_sid: (@ vault.twilio.api_key_sid )
+api_key_secret: (@ vault.twilio.api_key_secret )
 account_sid: (@ vault.twilio.account_sid )
 flex_flow_sid: (@ vault.twilio_flex.flex_flow_sid )
 flex_chat_service_sid: (@ vault.twilio_flex.flex_chat_service_sid )

--- a/vault.yaml
+++ b/vault.yaml
@@ -1,5 +1,6 @@
 twilio.account_sid: xxx
-twilio.auth_token: xxx
+twilio.api_key_secret: xxx
+twilio.api_key_sid: xxx
 twilio.phone_number: '+18005551234'
 twilio_flex.flex_flow_sid: xxx
 twilio_flex.flex_chat_service_sid: xxx


### PR DESCRIPTION
Auth token authentication is deprecated. This update replaces the auth token with an API key.

[Loom demo](https://www.loom.com/share/915aae2bf25b49c0811a2b22c204df7e)
[Codepen](https://codepen.io/ekalvi/pen/vYywdbq)